### PR TITLE
Fix middleware mispelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ backend/
 │   └── ProxLock/
 │       ├── Controllers/      # Request handlers
 │       ├── DTOs/             # Data transfer objects
-│       ├── Middlewear/       # Custom middleware
+│       ├── Middleware/       # Custom middleware
 │       ├── Migrations/       # Database migrations
 │       ├── Models/           # Database models
 │       ├── Webhooks/         # Webhook handlers

--- a/Sources/ProxLock/Middleware/CorsMiddleware.swift
+++ b/Sources/ProxLock/Middleware/CorsMiddleware.swift
@@ -14,4 +14,4 @@ private let corsConfiguration = CORSMiddleware.Configuration(
     allowedHeaders: [.accept, .authorization, .contentType, .origin, .xRequestedWith, .userAgent, .accessControlAllowOrigin],
     allowCredentials: true
 )
-let corsMiddlewear = CORSMiddleware(configuration: corsConfiguration)
+let corsMiddleware = CORSMiddleware(configuration: corsConfiguration)

--- a/Sources/ProxLock/Middleware/DeviceValidationMiddleware.swift
+++ b/Sources/ProxLock/Middleware/DeviceValidationMiddleware.swift
@@ -1,5 +1,5 @@
 //
-//  DeviceValidationMiddlewear.swift
+//  DeviceValidationMiddleware.swift
 //  APIProxy
 //
 //  Created by Morris Richman on 10/10/25.
@@ -11,7 +11,7 @@ import VaporDeviceCheck
 import Fluent
 import JWTKit
 
-struct DeviceValidationMiddlewear: AsyncMiddleware {
+struct DeviceValidationMiddleware: AsyncMiddleware {
     func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
         guard let modeString = request.headers.first(name: DeviceValidationHeaderKeys.validationMode), let mode = DeviceValidationMode(rawValue: modeString) else {
             throw Abort(.unauthorized, reason: "Failed Device Validation: Mode not detected")
@@ -46,14 +46,14 @@ struct DeviceValidationMiddlewear: AsyncMiddleware {
         // Add ECDSA key with JWKIdentifier
         await request.application.jwt.keys.add(ecdsa: privateKey, kid: kid)
         
-        let deviceCheckMiddlewear = DeviceCheck(
+        let deviceCheckMiddleware = DeviceCheck(
             jwkKid: kid,
             jwkIss: key.teamID,
             excludes: [["health"]],
             bypassTokens: [key.bypassToken]
         )
         
-        let deviceCheckEventLoopFuture = deviceCheckMiddlewear.respond(to: request, chainingTo: next)
+        let deviceCheckEventLoopFuture = deviceCheckMiddleware.respond(to: request, chainingTo: next)
         
         let response = try await withCheckedThrowingContinuation { continuation in
             deviceCheckEventLoopFuture.whenComplete { result in

--- a/Sources/ProxLock/configure.swift
+++ b/Sources/ProxLock/configure.swift
@@ -9,7 +9,7 @@ public func configure(_ app: Application) async throws {
     // app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     
     // cors middleware should come before default error middleware using `at: .beginning`
-    app.middleware.use(corsMiddlewear, at: .beginning)
+    app.middleware.use(corsMiddleware, at: .beginning)
     
     app.databases.use(DatabaseConfigurationFactory.postgres(configuration: .init(
         hostname: Environment.get("DATABASE_HOST") ?? "localhost",

--- a/Sources/ProxLock/routes.swift
+++ b/Sources/ProxLock/routes.swift
@@ -19,7 +19,7 @@ app.get { req async in
 }
 
 private func registerV1Routes<R: RoutesBuilder>(_ v1: R) throws {
-    try v1.grouped(DeviceValidationMiddlewear()).register(collection: RequestProxyController())
+    try v1.grouped(DeviceValidationMiddleware()).register(collection: RequestProxyController())
     
     let v1_authenticatedRouters = v1.grouped(ClerkAuthenticator())
     


### PR DESCRIPTION
It has come to my attention that Middleware was misspelled as Middlewear. This pull request fixes that.