### PR TITLE
Improve Speed via Caching

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9d2ac8c21de3185c420831ea8998eece29645e7cc13e9ad2200340af819b4a70",
+  "originHash" : "4e52525565b7c9c7a19adaf0c736f159252dc7dfb698e23c095c642eb51ed01f",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -107,6 +107,15 @@
       "state" : {
         "revision" : "8ee6118c03501196be183b0938d2ec4478c18954",
         "version" : "1.27.0"
+      }
+    },
+    {
+      "identity" : "queues",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/queues",
+      "state" : {
+        "revision" : "4fa1ef91821fee04cce1982ba053ab37b88abfb9",
+        "version" : "1.18.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .package(url: "https://github.com/mcrich23/vapordevicecheck.git", from: "1.1.3"),
         .package(url: "https://github.com/apple/swift-crypto", from: "3.0.0"),
         .package(url: "https://github.com/mcrich23/google-cloud-kit.git", branch: "main"),
+        .package(url: "https://github.com/vapor/queues.git", from: "1.18.0"),
     ],
     targets: [
         .executableTarget(
@@ -33,6 +34,7 @@ let package = Package(
                 .product(name: "VaporDeviceCheck", package: "VaporDeviceCheck"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "GoogleCloudKit", package: "google-cloud-kit"),
+                .product(name: "Queues", package: "queues"),
             ],
             swiftSettings: swiftSettings
         )

--- a/Sources/ProxLock/Cache.swift
+++ b/Sources/ProxLock/Cache.swift
@@ -20,6 +20,7 @@ actor Cache {
     private var apiKeys: [APIKey.IDValue: CacheValue<APIKey>] = [:]
     private var projects: [Project.IDValue: CacheValue<Project>] = [:]
     private var users: [User.IDValue: CacheValue<User>] = [:]
+    private var clerkIDUsers: [String: CacheValue<User>] = [:]
     
     /// Gets an ``APIKey`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
     func getAPIKey(_ id: APIKey.IDValue, on db: any Database) async throws -> APIKey? {
@@ -68,6 +69,28 @@ actor Cache {
         }
         
         users[id] = CacheValue(value: item, expiry: generateExpiration())
+        clerkIDUsers[item.clerkID] = CacheValue(value: item, expiry: generateExpiration())
+        
+        return item
+    }
+    
+    /// Gets a ``User`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
+    func getUser(clerkID: String, on db: any Database) async throws -> User? {
+        if let item = clerkIDUsers[clerkID], item.expiry > Date() {
+            return item.value
+        }
+        
+        // Get Project so we can fetch the user
+        guard let item = try await User.query(on: db).filter(\.$clerkID == clerkID).first() else {
+            clerkIDUsers.removeValue(forKey: clerkID)
+            return nil
+        }
+        
+        clerkIDUsers[clerkID] = CacheValue(value: item, expiry: generateExpiration())
+        
+        if let userID = item.id {
+            users[userID] = CacheValue(value: item, expiry: generateExpiration())
+        }
         
         return item
     }

--- a/Sources/ProxLock/Cache.swift
+++ b/Sources/ProxLock/Cache.swift
@@ -138,7 +138,6 @@ extension ParentProperty where From == MonthlyUserUsageHistory, To == User {
     }
 }
 
-
 extension ParentProperty where From == DailyUserUsageHistory, To == User {
     func cachedGet(on db: any Database) async throws -> User {
         guard let item = try await Cache.shared.getUser(id, on: db) else {

--- a/Sources/ProxLock/Cache.swift
+++ b/Sources/ProxLock/Cache.swift
@@ -1,0 +1,43 @@
+//
+//  Cache.swift
+//  ProxLock
+//
+//  Created by Morris Richman on 3/7/26.
+//
+
+import Vapor
+import Fluent
+
+struct CacheValue<T> {
+    let value: T
+    let expiry: Date
+}
+
+/// A cache of various objects that holds for 1 hour after initial fetch
+actor Cache {
+    static let shared = Cache()
+    
+    private var apiKeys: [APIKey.IDValue: CacheValue<APIKey>] = [:]
+    
+    /// Gets an ``APIKey`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
+    func getAPIKey(request: Request, for id: APIKey.IDValue) async throws -> APIKey? {
+        if let key = apiKeys[id], key.expiry > Date() {
+            return key.value
+        }
+        
+        // Get Project so we can fetch the user
+        guard let dbKey = try await APIKey.find(id, on: request.db) else {
+            apiKeys.removeValue(forKey: id)
+            return nil
+        }
+        
+        apiKeys[id] = CacheValue(value: dbKey, expiry: generateExpiration())
+        
+        return dbKey
+    }
+    
+    /// Generates an expiration date of 1 hour from now
+    private func generateExpiration() -> Date {
+        .now.addingTimeInterval(60*60)
+    }
+}

--- a/Sources/ProxLock/Cache.swift
+++ b/Sources/ProxLock/Cache.swift
@@ -32,6 +32,12 @@ struct CacheCleanupJob: AsyncScheduledJob {
             guard let id = item.value.value.id else { continue }
             await cache.removeUser(id)
         }
+        for item in await cache.monthlyUserUsage.filter({ $0.value.expiry < Date() }) {
+            await cache.removeMonthlyUserUsage(for: item.key)
+        }
+        for item in await cache.dailyUserUsage.filter({ $0.value.expiry < Date() }) {
+            await cache.removeDailyUserUsage(for: item.key)
+        }
     }
 }
 
@@ -58,6 +64,8 @@ actor Cache {
     fileprivate var projects: [Project.IDValue: CacheValue<Project>] = [:]
     fileprivate var users: [User.IDValue: CacheValue<User>] = [:]
     fileprivate var clerkIDUsers: [String: CacheValue<User>] = [:]
+    internal var monthlyUserUsage: [CacheUsageLookup: CacheValue<MonthlyUserUsageHistory>] = [:]
+    internal var dailyUserUsage: [CacheUsageLookup: CacheValue<DailyUserUsageHistory>] = [:]
     
     /// Gets an ``APIKey`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
     func getAPIKey(_ id: APIKey.IDValue, on db: any Database) async throws -> APIKey? {
@@ -133,7 +141,7 @@ actor Cache {
     }
     
     /// Generates an expiration date of 1 hour from now
-    private func generateExpiration() -> Date {
+    internal func generateExpiration() -> Date {
         .now.addingTimeInterval(60*60)
     }
 }

--- a/Sources/ProxLock/Cache.swift
+++ b/Sources/ProxLock/Cache.swift
@@ -7,20 +7,57 @@
 
 import Vapor
 import Fluent
+import Queues
 
-struct CacheValue<T> {
+struct CacheValue<T> : Sendable where T: Sendable {
     let value: T
     let expiry: Date
+}
+
+/// Cleans Up Cache
+struct CacheCleanupJob: AsyncScheduledJob {
+    private let cache = Cache.shared
+
+    func run(context: QueueContext) async throws {
+        for item in await cache.apiKeys.filter({ $0.value.expiry < Date() }) {
+            await cache.removeAPIKey(item.key)
+        }
+        for item in await cache.projects.filter({ $0.value.expiry < Date() }) {
+            await cache.removeProject(item.key)
+        }
+        for item in await cache.users.filter({ $0.value.expiry < Date() }) {
+            await cache.removeUser(item.key)
+        }
+        for item in await cache.clerkIDUsers.filter({ $0.value.expiry < Date() }) {
+            guard let id = item.value.value.id else { continue }
+            await cache.removeUser(id)
+        }
+    }
+}
+
+extension Cache {
+    fileprivate func removeAPIKey(_ id: APIKey.IDValue) async {
+        self.apiKeys.removeValue(forKey: id)
+    }
+    
+    fileprivate func removeProject(_ id: Project.IDValue) async {
+        self.projects.removeValue(forKey: id)
+    }
+    
+    fileprivate func removeUser(_ id: User.IDValue) async {
+        self.users.removeValue(forKey: id)
+        self.clerkIDUsers.removeValue(forKey: "\(id)")
+    }
 }
 
 /// A cache of various objects that holds for 1 hour after initial fetch
 actor Cache {
     static let shared = Cache()
     
-    private var apiKeys: [APIKey.IDValue: CacheValue<APIKey>] = [:]
-    private var projects: [Project.IDValue: CacheValue<Project>] = [:]
-    private var users: [User.IDValue: CacheValue<User>] = [:]
-    private var clerkIDUsers: [String: CacheValue<User>] = [:]
+    fileprivate var apiKeys: [APIKey.IDValue: CacheValue<APIKey>] = [:]
+    fileprivate var projects: [Project.IDValue: CacheValue<Project>] = [:]
+    fileprivate var users: [User.IDValue: CacheValue<User>] = [:]
+    fileprivate var clerkIDUsers: [String: CacheValue<User>] = [:]
     
     /// Gets an ``APIKey`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
     func getAPIKey(_ id: APIKey.IDValue, on db: any Database) async throws -> APIKey? {

--- a/Sources/ProxLock/Cache.swift
+++ b/Sources/ProxLock/Cache.swift
@@ -29,8 +29,7 @@ struct CacheCleanupJob: AsyncScheduledJob {
             await cache.removeUser(item.key)
         }
         for item in await cache.clerkIDUsers.filter({ $0.value.expiry < Date() }) {
-            guard let id = item.value.value.id else { continue }
-            await cache.removeUser(id)
+            await cache.removeClerkIDUser(item.key)
         }
         for item in await cache.monthlyUserUsage.filter({ $0.value.expiry < Date() }) {
             await cache.removeMonthlyUserUsage(for: item.key)
@@ -52,7 +51,10 @@ extension Cache {
     
     fileprivate func removeUser(_ id: User.IDValue) async {
         self.users.removeValue(forKey: id)
-        self.clerkIDUsers.removeValue(forKey: "\(id)")
+    }
+    
+    fileprivate func removeClerkIDUser(_ id: String) async {
+        self.clerkIDUsers.removeValue(forKey: id)
     }
 }
 
@@ -162,6 +164,7 @@ extension Project {
 
 extension User {
     func delete(on db: any Database) async throws {
+        await Cache.shared.removeClerkIDUser(self.clerkID)
         try await Cache.shared.removeUser(self.requireID())
         try await self.delete(force: false, on: db)
     }

--- a/Sources/ProxLock/Cache.swift
+++ b/Sources/ProxLock/Cache.swift
@@ -19,43 +19,133 @@ actor Cache {
     
     private var apiKeys: [APIKey.IDValue: CacheValue<APIKey>] = [:]
     private var projects: [Project.IDValue: CacheValue<Project>] = [:]
+    private var users: [User.IDValue: CacheValue<User>] = [:]
     
     /// Gets an ``APIKey`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
-    func getAPIKey(_ request: Request, for id: APIKey.IDValue) async throws -> APIKey? {
-        if let key = apiKeys[id], key.expiry > Date() {
-            return key.value
+    func getAPIKey(_ id: APIKey.IDValue, on db: any Database) async throws -> APIKey? {
+        if let item = apiKeys[id], item.expiry > Date() {
+            return item.value
         }
         
         // Get Project so we can fetch the user
-        guard let dbKey = try await APIKey.find(id, on: request.db) else {
+        guard let item = try await APIKey.find(id, on: db) else {
             apiKeys.removeValue(forKey: id)
             return nil
         }
         
-        apiKeys[id] = CacheValue(value: dbKey, expiry: generateExpiration())
+        apiKeys[id] = CacheValue(value: item, expiry: generateExpiration())
         
-        return dbKey
+        return item
     }
     
-    /// Gets an ``Project`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
-    func getProject(_ request: Request, for id: Project.IDValue) async throws -> Project? {
-        if let key = projects[id], key.expiry > Date() {
-            return key.value
+    /// Gets a ``Project`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
+    func getProject(_ id: Project.IDValue, on db: any Database) async throws -> Project? {
+        if let item = projects[id], item.expiry > Date() {
+            return item.value
         }
         
         // Get Project so we can fetch the user
-        guard let dbKey = try await Project.find(id, on: request.db) else {
+        guard let item = try await Project.find(id, on: db) else {
             projects.removeValue(forKey: id)
             return nil
         }
         
-        projects[id] = CacheValue(value: dbKey, expiry: generateExpiration())
+        projects[id] = CacheValue(value: item, expiry: generateExpiration())
         
-        return dbKey
+        return item
+    }
+    
+    /// Gets a ``User`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
+    func getUser(_ id: User.IDValue, on db: any Database) async throws -> User? {
+        if let item = users[id], item.expiry > Date() {
+            return item.value
+        }
+        
+        // Get Project so we can fetch the user
+        guard let item = try await User.find(id, on: db) else {
+            users.removeValue(forKey: id)
+            return nil
+        }
+        
+        users[id] = CacheValue(value: item, expiry: generateExpiration())
+        
+        return item
     }
     
     /// Generates an expiration date of 1 hour from now
     private func generateExpiration() -> Date {
         .now.addingTimeInterval(60*60)
+    }
+}
+
+extension ParentProperty where From == APIKey, To == Project {
+    func cachedGet(on db: any Database) async throws -> Project {
+        guard let project = try await Cache.shared.getProject(id, on: db) else {
+            try await load(on: db)
+            return try await get(on: db)
+        }
+        
+        return project
+    }
+}
+
+extension ParentProperty where From == Project, To == User {
+    func cachedGet(on db: any Database) async throws -> User {
+        guard let item = try await Cache.shared.getUser(id, on: db) else {
+            try await load(on: db)
+            return try await get(on: db)
+        }
+        
+        return item
+    }
+}
+
+extension ParentProperty where From == User.AccessKey, To == User {
+    func cachedGet(on db: any Database) async throws -> User {
+        guard let item = try await Cache.shared.getUser(id, on: db) else {
+            try await load(on: db)
+            return try await get(on: db)
+        }
+        
+        return item
+    }
+}
+
+extension OptionalParentProperty where From == APIKey, To == User {
+    func cachedGet(on db: any Database) async throws -> User? {
+        guard let id else {
+            return nil
+        }
+        
+        guard let item = try await Cache.shared.getUser(id, on: db) else {
+            try await load(on: db)
+            return try await get(on: db)
+        }
+        
+        return item
+    }
+}
+
+
+extension ParentProperty where From == MonthlyUserUsageHistory, To == User {
+    func cachedGet(on db: any Database) async throws -> User {
+        guard let item = try await Cache.shared.getUser(id, on: db) else {
+            try await load(on: db)
+            return try await get(on: db)
+        }
+        
+        return item
+    }
+}
+
+
+extension ParentProperty where From == DailyUserUsageHistory, To == User {
+    func cachedGet(on db: any Database) async throws -> User {
+        guard let item = try await Cache.shared.getUser(id, on: db) else {
+            try await load(on: db)
+            return try await get(on: db)
+        }
+        
+        return item
     }
 }

--- a/Sources/ProxLock/Cache.swift
+++ b/Sources/ProxLock/Cache.swift
@@ -146,6 +146,27 @@ actor Cache {
     }
 }
 
+extension APIKey {
+    func delete(on db: any Database) async throws {
+        try await Cache.shared.removeAPIKey(self.requireID())
+        try await self.delete(force: false, on: db)
+    }
+}
+
+extension Project {
+    func delete(on db: any Database) async throws {
+        try await Cache.shared.removeProject(self.requireID())
+        try await self.delete(force: false, on: db)
+    }
+}
+
+extension User {
+    func delete(on db: any Database) async throws {
+        try await Cache.shared.removeUser(self.requireID())
+        try await self.delete(force: false, on: db)
+    }
+}
+
 extension ParentProperty where From == APIKey, To == Project {
     func cachedGet(on db: any Database) async throws -> Project {
         guard let project = try await Cache.shared.getProject(id, on: db) else {

--- a/Sources/ProxLock/Cache.swift
+++ b/Sources/ProxLock/Cache.swift
@@ -18,9 +18,10 @@ actor Cache {
     static let shared = Cache()
     
     private var apiKeys: [APIKey.IDValue: CacheValue<APIKey>] = [:]
+    private var projects: [Project.IDValue: CacheValue<Project>] = [:]
     
     /// Gets an ``APIKey`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
-    func getAPIKey(request: Request, for id: APIKey.IDValue) async throws -> APIKey? {
+    func getAPIKey(_ request: Request, for id: APIKey.IDValue) async throws -> APIKey? {
         if let key = apiKeys[id], key.expiry > Date() {
             return key.value
         }
@@ -32,6 +33,23 @@ actor Cache {
         }
         
         apiKeys[id] = CacheValue(value: dbKey, expiry: generateExpiration())
+        
+        return dbKey
+    }
+    
+    /// Gets an ``Project`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
+    func getProject(_ request: Request, for id: Project.IDValue) async throws -> Project? {
+        if let key = projects[id], key.expiry > Date() {
+            return key.value
+        }
+        
+        // Get Project so we can fetch the user
+        guard let dbKey = try await Project.find(id, on: request.db) else {
+            projects.removeValue(forKey: id)
+            return nil
+        }
+        
+        projects[id] = CacheValue(value: dbKey, expiry: generateExpiration())
         
         return dbKey
     }

--- a/Sources/ProxLock/Controllers/APIKeyController.swift
+++ b/Sources/ProxLock/Controllers/APIKeyController.swift
@@ -35,8 +35,9 @@ struct APIKeyController: RouteCollection {
         let user = try req.auth.require(User.self)
         
         guard let projectIDString = req.parameters.get("projectID"),
-                let projectID = UUID(uuidString: projectIDString),
-              let project = try await Project.query(on: req.db).filter(\.$id == projectID).filter(\.$user.$id == user.requireID()).with(\.$user).first() else {
+              let projectID = UUID(uuidString: projectIDString),
+              let project = try await Cache.shared.getProject(projectID, on: req.db),
+              try project.$user.id == user.requireID() else {
             throw Abort(.notFound)
         }
         
@@ -75,8 +76,9 @@ struct APIKeyController: RouteCollection {
         let user = try req.auth.require(User.self)
         
         guard let projectIDString = req.parameters.get("projectID"),
-                let projectID = UUID(uuidString: projectIDString),
-              let project = try await Project.query(on: req.db).filter(\.$id == projectID).filter(\.$user.$id == user.requireID()).with(\.$user).first() else {
+              let projectID = UUID(uuidString: projectIDString),
+              let project = try await Cache.shared.getProject(projectID, on: req.db),
+              try project.$user.id == user.requireID() else {
             throw Abort(.notFound)
         }
         try await project.$apiKeys.load(on: req.db)
@@ -142,12 +144,14 @@ struct APIKeyController: RouteCollection {
         let keyDTO = try req.content.decode(APIKeyRecievingDTO.self)
         
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-              let project = try await Project.query(on: req.db).filter(\.$id == projectID).filter(\.$user.$id == user.requireID()).with(\.$user).first() else {
+              let project = try await Cache.shared.getProject(projectID, on: req.db),
+              try project.$user.id == user.requireID() else {
             throw Abort(.notFound)
         }
 
         guard let keyID = req.parameters.get("keyID", as: UUID.self),
-              let key = try await APIKey.query(on: req.db).filter(\.$id == keyID).filter(\.$project.$id == project.requireID()).with(\.$project).first() else {
+              let key = try await Cache.shared.getAPIKey(keyID, on: req.db),
+              try key.$project.id == project.requireID() else {
             throw Abort(.notFound)
         }
         
@@ -213,12 +217,14 @@ struct APIKeyController: RouteCollection {
         let user = try req.auth.require(User.self)
         
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-              let project = try await Project.query(on: req.db).filter(\.$id == projectID).filter(\.$user.$id == user.requireID()).with(\.$user).first() else {
+              let project = try await Cache.shared.getProject(projectID, on: req.db),
+              try project.$user.id == user.requireID() else {
             throw Abort(.notFound)
         }
 
         guard let keyID = req.parameters.get("keyID", as: UUID.self),
-              let key = try await APIKey.query(on: req.db).filter(\.$id == keyID).filter(\.$project.$id == project.requireID()).with(\.$project).first() else {
+              let key = try await Cache.shared.getAPIKey(keyID, on: req.db),
+              try key.$project.id == project.requireID() else {
             throw Abort(.notFound)
         }
 
@@ -244,12 +250,14 @@ struct APIKeyController: RouteCollection {
         let user = try req.auth.require(User.self)
         
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-              let project = try await Project.query(on: req.db).filter(\.$id == projectID).filter(\.$user.$id == user.requireID()).with(\.$user).first() else {
+              let project = try await Cache.shared.getProject(projectID, on: req.db),
+              try project.$user.id == user.requireID() else {
             throw Abort(.notFound)
         }
 
         guard let keyID = req.parameters.get("keyID", as: UUID.self),
-              let key = try await APIKey.query(on: req.db).filter(\.$id == keyID).filter(\.$project.$id == project.requireID()).with(\.$project).first() else {
+              let key = try await Cache.shared.getAPIKey(keyID, on: req.db),
+              try key.$project.id == project.requireID() else {
             throw Abort(.notFound)
         }
 

--- a/Sources/ProxLock/Controllers/ProjectController.swift
+++ b/Sources/ProxLock/Controllers/ProjectController.swift
@@ -116,7 +116,8 @@ struct ProjectController: RouteCollection {
         let projectDTO = try req.content.decode(ProjectDTO.self)
         
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-              let dbProject = try await Project.query(on: req.db).filter(\.$id == projectID).filter(\.$user.$id == user.requireID()).with(\.$user).first() else {
+              let dbProject = try await Cache.shared.getProject(projectID, on: req.db),
+              try dbProject.$user.id == user.requireID() else {
             throw Abort(.notFound)
         }
         
@@ -154,7 +155,8 @@ struct ProjectController: RouteCollection {
         let user = try req.auth.require(User.self)
         
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-              let project = try await Project.query(on: req.db).filter(\.$id == projectID).filter(\.$user.$id == user.requireID()).with(\.$user).first() else {
+              let project = try await Cache.shared.getProject(projectID, on: req.db),
+              try project.$user.id == user.requireID() else {
             throw Abort(.notFound)
         }
 
@@ -179,7 +181,8 @@ struct ProjectController: RouteCollection {
         let user = try req.auth.require(User.self)
         
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-              let project = try await Project.query(on: req.db).filter(\.$id == projectID).filter(\.$user.$id == user.requireID()).with(\.$user).first() else {
+              let project = try await Cache.shared.getProject(projectID, on: req.db),
+              try project.$user.id == user.requireID() else {
             throw Abort(.notFound)
         }
 

--- a/Sources/ProxLock/Controllers/RequestProxyController.swift
+++ b/Sources/ProxLock/Controllers/RequestProxyController.swift
@@ -37,9 +37,13 @@ struct RequestProxyController: RouteCollection {
     @Sendable
     func proxyRequest(req: Request) async throws -> ClientResponse {
         var headers = req.headers
-        guard let associationId = headers.first(name: ProxyHeaderKeys.associationId) else {
+        guard let associationIdString = headers.first(name: ProxyHeaderKeys.associationId) else {
             throw Abort(.badRequest, reason: ProxyError.associationIdMissing.localizedDescription)
         }
+        guard let associationId = UUID(uuidString: associationIdString) else {
+            throw Abort(.badRequest, reason: "Unexpected error parsing association ID from request headers.")
+        }
+        
         guard let partialKey = headers.first(where: { $0.value.contains(ProxyHeaderKeys.partialKeyIdentifier)}) else {
             throw Abort(.badRequest, reason: ProxyError.partialKeyMissing.localizedDescription)
         }
@@ -64,7 +68,7 @@ struct RequestProxyController: RouteCollection {
         headers.remove(name: "Host")
         
         // Get Full Key
-        guard let dbKey = try await APIKey.find(UUID(uuidString: associationId), on: req.db) else {
+        guard let dbKey = try await Cache.shared.getAPIKey(request: req, for: associationId) else {
             throw Abort(.badRequest, reason: "Key was not found")
         }
         

--- a/Sources/ProxLock/Controllers/RequestProxyController.swift
+++ b/Sources/ProxLock/Controllers/RequestProxyController.swift
@@ -68,7 +68,7 @@ struct RequestProxyController: RouteCollection {
         headers.remove(name: "Host")
         
         // Get Full Key
-        guard let dbKey = try await Cache.shared.getAPIKey(req, for: associationId) else {
+        guard let dbKey = try await Cache.shared.getAPIKey(associationId, on: req.db) else {
             throw Abort(.badRequest, reason: "Key was not found")
         }
         

--- a/Sources/ProxLock/Controllers/RequestProxyController.swift
+++ b/Sources/ProxLock/Controllers/RequestProxyController.swift
@@ -68,7 +68,7 @@ struct RequestProxyController: RouteCollection {
         headers.remove(name: "Host")
         
         // Get Full Key
-        guard let dbKey = try await Cache.shared.getAPIKey(request: req, for: associationId) else {
+        guard let dbKey = try await Cache.shared.getAPIKey(req, for: associationId) else {
             throw Abort(.badRequest, reason: "Key was not found")
         }
         

--- a/Sources/ProxLock/Controllers/Validation/DeviceCheckKeyController.swift
+++ b/Sources/ProxLock/Controllers/Validation/DeviceCheckKeyController.swift
@@ -80,7 +80,7 @@ struct DeviceCheckKeyController: RouteCollection {
     @Sendable
     func create(req: Request) async throws -> DeviceCheckKeySendingDTO {
         let user = try req.auth.require(User.self)
-        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Project.find(projectID, on: req.db) else {
+        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(req, for: projectID) else {
             throw Abort(.notFound)
         }
         
@@ -182,7 +182,7 @@ struct DeviceCheckKeyController: RouteCollection {
             throw Abort(.notFound)
         }
         
-        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Project.find(projectID, on: req.db) else {
+        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(req, for: projectID) else {
             throw Abort(.notFound)
         }
         
@@ -248,7 +248,7 @@ struct DeviceCheckKeyController: RouteCollection {
     @Sendable
     func get(req: Request) async throws -> DeviceCheckKeySendingDTO {
         let user = try req.auth.require(User.self)
-        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Project.find(projectID, on: req.db) else {
+        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(req, for: projectID) else {
             throw Abort(.notFound)
         }
         
@@ -283,7 +283,7 @@ struct DeviceCheckKeyController: RouteCollection {
     @Sendable
     func delete(req: Request) async throws -> HTTPStatus {
         let user = try req.auth.require(User.self)
-        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Project.find(projectID, on: req.db) else {
+        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(req, for: projectID) else {
             throw Abort(.notFound)
         }
         

--- a/Sources/ProxLock/Controllers/Validation/DeviceCheckKeyController.swift
+++ b/Sources/ProxLock/Controllers/Validation/DeviceCheckKeyController.swift
@@ -84,8 +84,6 @@ struct DeviceCheckKeyController: RouteCollection {
             throw Abort(.notFound)
         }
         
-        try await project.$user.load(on: req.db)
-        
         guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
@@ -186,8 +184,6 @@ struct DeviceCheckKeyController: RouteCollection {
             throw Abort(.notFound)
         }
         
-        try await project.$user.load(on: req.db)
-        
         guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
@@ -252,13 +248,9 @@ struct DeviceCheckKeyController: RouteCollection {
             throw Abort(.notFound)
         }
         
-        try await project.$user.load(on: req.db)
-        
         guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
-        
-        try await project.$deviceCheckKey.load(on: req.db)
         
         guard let key = try await project.$deviceCheckKey.get(on: req.db) else {
             throw Abort(.notFound)

--- a/Sources/ProxLock/Controllers/Validation/DeviceCheckKeyController.swift
+++ b/Sources/ProxLock/Controllers/Validation/DeviceCheckKeyController.swift
@@ -80,13 +80,13 @@ struct DeviceCheckKeyController: RouteCollection {
     @Sendable
     func create(req: Request) async throws -> DeviceCheckKeySendingDTO {
         let user = try req.auth.require(User.self)
-        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(req, for: projectID) else {
+        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(projectID, on: req.db) else {
             throw Abort(.notFound)
         }
         
         try await project.$user.load(on: req.db)
         
-        guard try await user.requireID() == project.$user.get(on: req.db).requireID() else {
+        guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
         
@@ -182,13 +182,13 @@ struct DeviceCheckKeyController: RouteCollection {
             throw Abort(.notFound)
         }
         
-        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(req, for: projectID) else {
+        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(projectID, on: req.db) else {
             throw Abort(.notFound)
         }
         
         try await project.$user.load(on: req.db)
         
-        guard try await user.requireID() == project.$user.get(on: req.db).requireID() else {
+        guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
         
@@ -248,13 +248,13 @@ struct DeviceCheckKeyController: RouteCollection {
     @Sendable
     func get(req: Request) async throws -> DeviceCheckKeySendingDTO {
         let user = try req.auth.require(User.self)
-        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(req, for: projectID) else {
+        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(projectID, on: req.db) else {
             throw Abort(.notFound)
         }
         
         try await project.$user.load(on: req.db)
         
-        guard try await user.requireID() == project.$user.get(on: req.db).requireID() else {
+        guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
         
@@ -283,13 +283,13 @@ struct DeviceCheckKeyController: RouteCollection {
     @Sendable
     func delete(req: Request) async throws -> HTTPStatus {
         let user = try req.auth.require(User.self)
-        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(req, for: projectID) else {
+        guard let projectID = req.parameters.get("projectID", as: UUID.self), let project = try await Cache.shared.getProject(projectID, on: req.db) else {
             throw Abort(.notFound)
         }
         
         try await project.$user.load(on: req.db)
         
-        guard try await user.requireID() == project.$user.get(on: req.db).requireID() else {
+        guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
         

--- a/Sources/ProxLock/Controllers/Validation/PlayIntegrityConfigController.swift
+++ b/Sources/ProxLock/Controllers/Validation/PlayIntegrityConfigController.swift
@@ -73,7 +73,7 @@ struct PlayIntegrityConfigController: RouteCollection {
     func create(req: Request) async throws -> PlayIntegrityConfigSendingDTO {
         let user = try req.auth.require(User.self)
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-            let project = try await Project.find(projectID, on: req.db)
+              let project = try await Cache.shared.getProject(req, for: projectID)
         else {
             throw Abort(.notFound)
         }
@@ -117,7 +117,7 @@ struct PlayIntegrityConfigController: RouteCollection {
         let user = try req.auth.require(User.self)
         let dto = try req.content.decode(PlayIntegrityConfigRecievingDTO.self)
 
-        guard let project = try await Project.find(req.parameters.require("projectID"), on: req.db) else {
+        guard let project = try await Cache.shared.getProject(req, for: req.parameters.require("projectID")) else {
             throw Abort(.notFound)
         }
 
@@ -166,7 +166,7 @@ struct PlayIntegrityConfigController: RouteCollection {
         let user = try req.auth.require(User.self)
         let dto = try req.content.decode(PlayIntegrityConfigLinkRecievingDTO.self)
 
-        guard let project = try await Project.find(dto.projectID, on: req.db) else {
+        guard let project = try await Cache.shared.getProject(req, for: dto.projectID) else {
             throw Abort(.notFound)
         }
 
@@ -183,7 +183,7 @@ struct PlayIntegrityConfigController: RouteCollection {
         }
 
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-            let project = try await Project.find(projectID, on: req.db)
+            let project = try await Cache.shared.getProject(req, for: projectID)
         else {
             throw Abort(.notFound)
         }
@@ -216,7 +216,7 @@ struct PlayIntegrityConfigController: RouteCollection {
     func get(req: Request) async throws -> PlayIntegrityConfigSendingDTO {
         let user = try req.auth.require(User.self)
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-            let project = try await Project.find(projectID, on: req.db)
+            let project = try await Cache.shared.getProject(req, for: projectID)
         else {
             throw Abort(.notFound)
         }
@@ -253,7 +253,7 @@ struct PlayIntegrityConfigController: RouteCollection {
     func delete(req: Request) async throws -> HTTPStatus {
         let user = try req.auth.require(User.self)
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-            let project = try await Project.find(projectID, on: req.db)
+            let project = try await Cache.shared.getProject(req, for: projectID)
         else {
             throw Abort(.notFound)
         }

--- a/Sources/ProxLock/Controllers/Validation/PlayIntegrityConfigController.swift
+++ b/Sources/ProxLock/Controllers/Validation/PlayIntegrityConfigController.swift
@@ -73,14 +73,14 @@ struct PlayIntegrityConfigController: RouteCollection {
     func create(req: Request) async throws -> PlayIntegrityConfigSendingDTO {
         let user = try req.auth.require(User.self)
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-              let project = try await Cache.shared.getProject(req, for: projectID)
+              let project = try await Cache.shared.getProject(projectID, on: req.db)
         else {
             throw Abort(.notFound)
         }
 
         try await project.$user.load(on: req.db)
 
-        guard try await user.requireID() == project.$user.get(on: req.db).requireID() else {
+        guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
 
@@ -117,12 +117,12 @@ struct PlayIntegrityConfigController: RouteCollection {
         let user = try req.auth.require(User.self)
         let dto = try req.content.decode(PlayIntegrityConfigRecievingDTO.self)
 
-        guard let project = try await Cache.shared.getProject(req, for: req.parameters.require("projectID")) else {
+        guard let project = try await Cache.shared.getProject(req.parameters.require("projectID"), on: req.db) else {
             throw Abort(.notFound)
         }
 
         try await project.$user.load(on: req.db)
-        guard try await project.$user.get(on: req.db).requireID() == user.requireID() else {
+        guard try await project.$user.cachedGet(on: req.db).requireID() == user.requireID() else {
             throw Abort(.notFound)
         }
 
@@ -166,12 +166,12 @@ struct PlayIntegrityConfigController: RouteCollection {
         let user = try req.auth.require(User.self)
         let dto = try req.content.decode(PlayIntegrityConfigLinkRecievingDTO.self)
 
-        guard let project = try await Cache.shared.getProject(req, for: dto.projectID) else {
+        guard let project = try await Cache.shared.getProject(dto.projectID, on: req.db) else {
             throw Abort(.notFound)
         }
 
         try await project.$user.load(on: req.db)
-        guard try await project.$user.get(on: req.db).requireID() == user.requireID() else {
+        guard try await project.$user.cachedGet(on: req.db).requireID() == user.requireID() else {
             throw Abort(.notFound)
         }
 
@@ -183,14 +183,14 @@ struct PlayIntegrityConfigController: RouteCollection {
         }
 
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-            let project = try await Cache.shared.getProject(req, for: projectID)
+            let project = try await Cache.shared.getProject(projectID, on: req.db)
         else {
             throw Abort(.notFound)
         }
 
         try await project.$user.load(on: req.db)
 
-        guard try await user.requireID() == project.$user.get(on: req.db).requireID() else {
+        guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
 
@@ -216,14 +216,14 @@ struct PlayIntegrityConfigController: RouteCollection {
     func get(req: Request) async throws -> PlayIntegrityConfigSendingDTO {
         let user = try req.auth.require(User.self)
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-            let project = try await Cache.shared.getProject(req, for: projectID)
+            let project = try await Cache.shared.getProject(projectID, on: req.db)
         else {
             throw Abort(.notFound)
         }
 
         try await project.$user.load(on: req.db)
 
-        guard try await user.requireID() == project.$user.get(on: req.db).requireID() else {
+        guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
 
@@ -253,14 +253,14 @@ struct PlayIntegrityConfigController: RouteCollection {
     func delete(req: Request) async throws -> HTTPStatus {
         let user = try req.auth.require(User.self)
         guard let projectID = req.parameters.get("projectID", as: UUID.self),
-            let project = try await Cache.shared.getProject(req, for: projectID)
+            let project = try await Cache.shared.getProject(projectID, on: req.db)
         else {
             throw Abort(.notFound)
         }
 
         try await project.$user.load(on: req.db)
 
-        guard try await user.requireID() == project.$user.get(on: req.db).requireID() else {
+        guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
 

--- a/Sources/ProxLock/Controllers/Validation/PlayIntegrityConfigController.swift
+++ b/Sources/ProxLock/Controllers/Validation/PlayIntegrityConfigController.swift
@@ -78,8 +78,6 @@ struct PlayIntegrityConfigController: RouteCollection {
             throw Abort(.notFound)
         }
 
-        try await project.$user.load(on: req.db)
-
         guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
         }
@@ -121,7 +119,6 @@ struct PlayIntegrityConfigController: RouteCollection {
             throw Abort(.notFound)
         }
 
-        try await project.$user.load(on: req.db)
         guard try await project.$user.cachedGet(on: req.db).requireID() == user.requireID() else {
             throw Abort(.notFound)
         }
@@ -169,8 +166,7 @@ struct PlayIntegrityConfigController: RouteCollection {
         guard let project = try await Cache.shared.getProject(dto.projectID, on: req.db) else {
             throw Abort(.notFound)
         }
-
-        try await project.$user.load(on: req.db)
+        
         guard try await project.$user.cachedGet(on: req.db).requireID() == user.requireID() else {
             throw Abort(.notFound)
         }
@@ -187,8 +183,6 @@ struct PlayIntegrityConfigController: RouteCollection {
         else {
             throw Abort(.notFound)
         }
-
-        try await project.$user.load(on: req.db)
 
         guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
@@ -220,8 +214,6 @@ struct PlayIntegrityConfigController: RouteCollection {
         else {
             throw Abort(.notFound)
         }
-
-        try await project.$user.load(on: req.db)
 
         guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)
@@ -257,8 +249,6 @@ struct PlayIntegrityConfigController: RouteCollection {
         else {
             throw Abort(.notFound)
         }
-
-        try await project.$user.load(on: req.db)
 
         guard try await user.requireID() == project.$user.cachedGet(on: req.db).requireID() else {
             throw Abort(.notFound)

--- a/Sources/ProxLock/Enterprise-Exclusive/Cache+UsageHistory.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Cache+UsageHistory.swift
@@ -89,3 +89,20 @@ extension Cache {
         dailyUserUsage.removeValue(forKey: key)
     }
 }
+
+extension DailyUserUsageHistory {
+    func delete(on db: any Database) async throws {
+        try await $monthlyUsage.load(on: db)
+        let monthUsage = try await $monthlyUsage.get(on: db)
+        
+        await Cache.shared.removeDailyUserUsage(for: CacheUsageLookup(date: self.day, userID: monthUsage.$user.id))
+        try await self.delete(force: false, on: db)
+    }
+}
+
+extension MonthlyUserUsageHistory {
+    func delete(on db: any Database) async throws {
+        await Cache.shared.removeMonthlyUserUsage(for: CacheUsageLookup(date: self.month, userID: $user.id))
+        try await self.delete(force: false, on: db)
+    }
+}

--- a/Sources/ProxLock/Enterprise-Exclusive/Cache+UsageHistory.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Cache+UsageHistory.swift
@@ -49,7 +49,7 @@ extension Cache {
         }
         
         // Get Project so we can fetch the user
-        let item = try await user.getOrCreateCurrentMonthlyHistoricalRecord(db: db)
+        let item = try await user.getOrCreateMonthlyHistoricalRecord(date, db: db)
         
         monthlyUserUsage[lookup] = CacheValue(value: item, expiry: generateExpiration())
         
@@ -74,7 +74,7 @@ extension Cache {
         let month = try await getOrCreateMonthlyUserUsageHistory(date, userID: userID, on: db)
         
         // Get Project so we can fetch the user
-        let item = try await month.getOrCreateCurrentDailyHistoricalRecord(db: db)
+        let item = try await month.getOrCreateDailyHistoricalRecord(date, db: db)
         
         dailyUserUsage[lookup] = CacheValue(value: item, expiry: generateExpiration())
         

--- a/Sources/ProxLock/Enterprise-Exclusive/Cache+UsageHistory.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Cache+UsageHistory.swift
@@ -1,0 +1,91 @@
+//
+//  Cache+UsageHistory.swift
+//  ProxLock
+//
+//  Created by Morris Richman on 3/7/26.
+//
+
+import Foundation
+import Vapor
+import Fluent
+
+struct CacheUsageLookup: Sendable, Hashable {
+    let date: Date
+    let userID: User.IDValue
+}
+
+extension Cache {
+    private func normalizeMonth(_ date: Date) -> Date {
+        var calendar = Calendar.autoupdatingCurrent
+        calendar.timeZone = .gmt
+        
+        return date.startOfMonth(calendar: calendar)
+    }
+    private func normalizeDay(_ date: Date) -> Date {
+        var calendar = Calendar.autoupdatingCurrent
+        calendar.timeZone = .gmt
+        
+        return date.startOfDay(calendar: calendar)
+    }
+    
+    /// Gets/Creates a ``MonthlyUserUsageHistory`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
+    ///
+    /// - Parameters:
+    ///   - date: The date for that month. This will automatically be normalized to the beginning of the month.
+    ///   - userID: The ID of the ``User`` that you are performing the lookup for.
+    ///   - db: The database you might perform the lookup on.
+    func getOrCreateMonthlyUserUsageHistory(_ date: Date, userID: User.IDValue, on db: any Database) async throws -> MonthlyUserUsageHistory {
+        let date = normalizeMonth(date)
+        
+        let lookup = CacheUsageLookup(date: date, userID: userID)
+        
+        if let item = monthlyUserUsage[lookup], item.expiry > Date() {
+            return item.value
+        }
+        
+        guard let user = try await getUser(userID, on: db) else {
+            monthlyUserUsage.removeValue(forKey: lookup)
+            throw Abort(.notFound, reason: "User not found")
+        }
+        
+        // Get Project so we can fetch the user
+        let item = try await user.getOrCreateCurrentMonthlyHistoricalRecord(db: db)
+        
+        monthlyUserUsage[lookup] = CacheValue(value: item, expiry: generateExpiration())
+        
+        return item
+    }
+    
+    /// Gets/Creates a ``DailyUserUsageHistory`` from the cache if available, otherwise it pulls it from the database and stores it in the cache for future use.
+    ///
+    /// - Parameters:
+    ///   - date: The date for that day. This will automatically be normalized to the beginning of the day.
+    ///   - userID: The ID of the ``User`` that you are performing the lookup for.
+    ///   - db: The database you might perform the lookup on.
+    func getOrCreateDailyUserUsageHistory(_ date: Date, userID: User.IDValue, on db: any Database) async throws -> DailyUserUsageHistory {
+        let date = normalizeDay(date)
+        
+        let lookup = CacheUsageLookup(date: date, userID: userID)
+        
+        if let item = dailyUserUsage[lookup], item.expiry > Date() {
+            return item.value
+        }
+        
+        let month = try await getOrCreateMonthlyUserUsageHistory(date, userID: userID, on: db)
+        
+        // Get Project so we can fetch the user
+        let item = try await month.getOrCreateCurrentDailyHistoricalRecord(db: db)
+        
+        dailyUserUsage[lookup] = CacheValue(value: item, expiry: generateExpiration())
+        
+        return item
+    }
+    
+    internal func removeMonthlyUserUsage(for key: CacheUsageLookup) {
+        monthlyUserUsage.removeValue(forKey: key)
+    }
+    
+    internal func removeDailyUserUsage(for key: CacheUsageLookup) {
+        dailyUserUsage.removeValue(forKey: key)
+    }
+}

--- a/Sources/ProxLock/Enterprise-Exclusive/Controllers/RequestProxyController+Billing.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Controllers/RequestProxyController+Billing.swift
@@ -14,20 +14,20 @@ extension RequestProxyController {
             return true
         }
         
-        let currentRecord = try await user.getOrCreateCurrentMonthlyHistoricalRecord(req: req)
+        let currentRecord = try await Cache.shared.getOrCreateMonthlyUserUsageHistory(.now, userID: user.requireID(), on: req.db)
         
         return currentRecord.requestCount < user.monthlyRequestLimit
     }
     
     func addToUsersRequestHistory(req: Request, dbKey: APIKey, with user: User) async throws {
         // Get Historical Log
-        let monthlyEntry = try await user.getOrCreateCurrentMonthlyHistoricalRecord(req: req)
+        let monthlyEntry = try await Cache.shared.getOrCreateMonthlyUserUsageHistory(.now, userID: user.requireID(), on: req.db)
         
         // Update Entry
         monthlyEntry.requestCount += 1
         try await monthlyEntry.save(on: req.db)
         
-        let dailyEntry = try await monthlyEntry.getOrCreateCurrentDailyHistoricalRecord(req: req)
+        let dailyEntry = try await Cache.shared.getOrCreateDailyUserUsageHistory(.now, userID: user.requireID(), on: req.db)
         dailyEntry.requestCount += 1
         try await dailyEntry.save(on: req.db)
     }

--- a/Sources/ProxLock/Enterprise-Exclusive/Models/MonthlyUserUsageHistory.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Models/MonthlyUserUsageHistory.swift
@@ -52,7 +52,7 @@ final class MonthlyUserUsageHistory: Model, @unchecked Sendable {
         
         if historyEntry == nil {
             try await $user.load(on: db)
-            let user = try await $user.get(on: db)
+            let user = try await $user.cachedGet(on: db)
             
             let newEntry = DailyUserUsageHistory(requestCount: 0, subscription: user.currentSubscription ?? .free, day: Date().startOfDay(calendar: calendar))
             

--- a/Sources/ProxLock/Enterprise-Exclusive/Models/MonthlyUserUsageHistory.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Models/MonthlyUserUsageHistory.swift
@@ -39,10 +39,16 @@ final class MonthlyUserUsageHistory: Model, @unchecked Sendable {
         return .init(id: try requireID(), requestCount: requestCount, subscription: subscription, month: month)
     }
     
+    /// Gets the current days's historical record or creates it if necessary.
+    ///
+    /// - Warning: This method does not use the cache.
     func getOrCreateCurrentDailyHistoricalRecord(req: Request) async throws -> DailyUserUsageHistory {
         try await getOrCreateCurrentDailyHistoricalRecord(db: req.db)
     }
     
+    /// Gets the current days's historical record or creates it if necessary.
+    ///
+    /// - Warning: This method does not use the cache.
     func getOrCreateCurrentDailyHistoricalRecord(db: any Database) async throws -> DailyUserUsageHistory {
         // Get Historical Log
         var calendar = Calendar.autoupdatingCurrent

--- a/Sources/ProxLock/Enterprise-Exclusive/Models/MonthlyUserUsageHistory.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Models/MonthlyUserUsageHistory.swift
@@ -42,19 +42,19 @@ final class MonthlyUserUsageHistory: Model, @unchecked Sendable {
     /// Gets the current days's historical record or creates it if necessary.
     ///
     /// - Warning: This method does not use the cache.
-    func getOrCreateCurrentDailyHistoricalRecord(req: Request) async throws -> DailyUserUsageHistory {
-        try await getOrCreateCurrentDailyHistoricalRecord(db: req.db)
+    func getOrCreateDailyHistoricalRecord(_ date: Date, req: Request) async throws -> DailyUserUsageHistory {
+        try await getOrCreateDailyHistoricalRecord(date, db: req.db)
     }
     
     /// Gets the current days's historical record or creates it if necessary.
     ///
     /// - Warning: This method does not use the cache.
-    func getOrCreateCurrentDailyHistoricalRecord(db: any Database) async throws -> DailyUserUsageHistory {
+    func getOrCreateDailyHistoricalRecord(_ date: Date, db: any Database) async throws -> DailyUserUsageHistory {
         // Get Historical Log
         var calendar = Calendar.autoupdatingCurrent
         calendar.timeZone = .gmt
         
-        var historyEntry = try await DailyUserUsageHistory.query(on: db).filter(\.$day == Date().startOfDay(calendar: calendar)).filter(\.$monthlyUsage.$id == requireID()).with(\.$monthlyUsage).first()
+        var historyEntry = try await DailyUserUsageHistory.query(on: db).filter(\.$day == date.startOfDay(calendar: calendar)).filter(\.$monthlyUsage.$id == requireID()).with(\.$monthlyUsage).first()
         
         if historyEntry == nil {
             let user = try await $user.cachedGet(on: db)

--- a/Sources/ProxLock/Enterprise-Exclusive/Models/MonthlyUserUsageHistory.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Models/MonthlyUserUsageHistory.swift
@@ -57,7 +57,6 @@ final class MonthlyUserUsageHistory: Model, @unchecked Sendable {
         var historyEntry = try await DailyUserUsageHistory.query(on: db).filter(\.$day == Date().startOfDay(calendar: calendar)).filter(\.$monthlyUsage.$id == requireID()).with(\.$monthlyUsage).first()
         
         if historyEntry == nil {
-            try await $user.load(on: db)
             let user = try await $user.cachedGet(on: db)
             
             let newEntry = DailyUserUsageHistory(requestCount: 0, subscription: user.currentSubscription ?? .free, day: Date().startOfDay(calendar: calendar))

--- a/Sources/ProxLock/Enterprise-Exclusive/Models/User+Billing.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Models/User+Billing.swift
@@ -9,10 +9,16 @@ import Vapor
 import Fluent
 
 extension User {
+    /// Gets the current month's historical record or creates it if necessary.
+    ///
+    /// - Warning: This method does not use the cache.
     func getOrCreateCurrentMonthlyHistoricalRecord(req: Request) async throws -> MonthlyUserUsageHistory {
         try await getOrCreateCurrentMonthlyHistoricalRecord(db: req.db)
     }
     
+    /// Gets the current month's historical record or creates it if necessary.
+    ///
+    /// - Warning: This method does not use the cache.
     func getOrCreateCurrentMonthlyHistoricalRecord(db: any Database) async throws -> MonthlyUserUsageHistory {
         // Get Historical Log
         var calendar = Calendar.autoupdatingCurrent

--- a/Sources/ProxLock/Enterprise-Exclusive/Models/User+Billing.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Models/User+Billing.swift
@@ -12,19 +12,19 @@ extension User {
     /// Gets the current month's historical record or creates it if necessary.
     ///
     /// - Warning: This method does not use the cache.
-    func getOrCreateCurrentMonthlyHistoricalRecord(req: Request) async throws -> MonthlyUserUsageHistory {
-        try await getOrCreateCurrentMonthlyHistoricalRecord(db: req.db)
+    func getOrCreateMonthlyHistoricalRecord(_ date: Date, req: Request) async throws -> MonthlyUserUsageHistory {
+        try await getOrCreateMonthlyHistoricalRecord(date, db: req.db)
     }
     
     /// Gets the current month's historical record or creates it if necessary.
     ///
     /// - Warning: This method does not use the cache.
-    func getOrCreateCurrentMonthlyHistoricalRecord(db: any Database) async throws -> MonthlyUserUsageHistory {
+    func getOrCreateMonthlyHistoricalRecord(_ date: Date, db: any Database) async throws -> MonthlyUserUsageHistory {
         // Get Historical Log
         var calendar = Calendar.autoupdatingCurrent
         calendar.timeZone = .gmt
         
-        var historyEntry = try await MonthlyUserUsageHistory.query(on: db).filter(\.$month == Date().startOfMonth(calendar: calendar)).filter(\.$user.$id == requireID()).with(\.$user).first()
+        var historyEntry = try await MonthlyUserUsageHistory.query(on: db).filter(\.$month == date.startOfMonth(calendar: calendar)).filter(\.$user.$id == requireID()).with(\.$user).first()
         
         if historyEntry == nil {
             let newEntry = MonthlyUserUsageHistory(requestCount: 0, subscription: currentSubscription ?? .free, month: Date().startOfMonth(calendar: calendar))

--- a/Sources/ProxLock/Enterprise-Exclusive/Webhooks/ClerkSubscriptionsWebhook.swift
+++ b/Sources/ProxLock/Enterprise-Exclusive/Webhooks/ClerkSubscriptionsWebhook.swift
@@ -29,7 +29,7 @@ struct ClerkSubscriptionsWebhook: RouteCollection {
         
         let webhookItem: SubscriptionWebhookItem = try req.content.decode(SubscriptionWebhookItem.self, using: jsonDecoder)
         
-        guard let user = try await User.query(on: req.db).filter(\.$clerkID == webhookItem.data.payer.userId).first() else {
+        guard let user = try await Cache.shared.getUser(clerkID: webhookItem.data.payer.userId, on: req.db) else {
             throw Abort(.notFound)
         }
         
@@ -42,11 +42,11 @@ struct ClerkSubscriptionsWebhook: RouteCollection {
         user.currentSubscription = activeItem.plan.slug
         try await user.save(on: req.db)
         
-        let currentMonthlyUsageRecord = try await user.getOrCreateCurrentMonthlyHistoricalRecord(req: req)
+        let currentMonthlyUsageRecord = try await Cache.shared.getOrCreateMonthlyUserUsageHistory(.now, userID: user.requireID(), on: req.db)
         currentMonthlyUsageRecord.subscription.insert(activeItem.plan.slug)
         try await currentMonthlyUsageRecord.save(on: req.db)
         
-        let currentDailyUsageRecord = try await currentMonthlyUsageRecord.getOrCreateCurrentDailyHistoricalRecord(req: req)
+        let currentDailyUsageRecord = try await Cache.shared.getOrCreateDailyUserUsageHistory(.now, userID: user.requireID(), on: req.db)
         currentDailyUsageRecord.subscription.insert(activeItem.plan.slug)
         try await currentDailyUsageRecord.save(on: req.db)
         

--- a/Sources/ProxLock/Middleware/Authenticator.swift
+++ b/Sources/ProxLock/Middleware/Authenticator.swift
@@ -54,7 +54,6 @@ struct Authenticator: AsyncBearerAuthenticator {
         guard let key = try await User.AccessKey.find(bearer.token, on: request.db) else {
             throw Errors.userNotFound
         }
-        try await key.$user.load(on: request.db)
         let user = try await key.$user.cachedGet(on: request.db)
         
         try validateAdminAccess(for: request, with: user.clerkID)

--- a/Sources/ProxLock/Middleware/Authenticator.swift
+++ b/Sources/ProxLock/Middleware/Authenticator.swift
@@ -75,7 +75,7 @@ struct Authenticator: AsyncBearerAuthenticator {
                 return
             }
             
-            guard let user = try await User.query(on: request.db).filter(\.$clerkID == claims.id).first() else {
+            guard let user = try await Cache.shared.getUser(clerkID: claims.id, on: request.db) else {
                 throw Errors.userNotFound
             }
             request.auth.login(user)
@@ -100,7 +100,7 @@ struct Authenticator: AsyncBearerAuthenticator {
             return false
         }
         
-        guard let user = try await User.query(on: request.db).filter(\.$clerkID == userID).first() else {
+        guard let user = try await Cache.shared.getUser(clerkID: userID, on: request.db) else {
             throw Errors.userNotFound
         }
         

--- a/Sources/ProxLock/Middleware/Authenticator.swift
+++ b/Sources/ProxLock/Middleware/Authenticator.swift
@@ -55,7 +55,7 @@ struct Authenticator: AsyncBearerAuthenticator {
             throw Errors.userNotFound
         }
         try await key.$user.load(on: request.db)
-        let user = try await key.$user.get(on: request.db)
+        let user = try await key.$user.cachedGet(on: request.db)
         
         try validateAdminAccess(for: request, with: user.clerkID)
         guard try await !didImpersonateFromAdmin(for: request, adminUserID: user.clerkID) else {

--- a/Sources/ProxLock/Middleware/DeviceValidationMiddleware.swift
+++ b/Sources/ProxLock/Middleware/DeviceValidationMiddleware.swift
@@ -158,12 +158,15 @@ struct DeviceValidationMiddleware: AsyncMiddleware {
     }
     
     private func getDBKey(from request: Request) async throws -> APIKey {
-        guard let associationId = request.headers.first(name: ProxyHeaderKeys.associationId) else {
+        guard let associationIdString = request.headers.first(name: ProxyHeaderKeys.associationId) else {
             throw Abort(.unauthorized, reason: "Failed Device Validation: Association ID not detected")
+        }
+        guard let associationId = UUID(uuidString: associationIdString) else {
+            throw Abort(.badRequest, reason: "Unexpected error parsing association ID from request headers.")
         }
         
         // Get Project so we can fetch the user
-        guard let dbKey = try await APIKey.find(UUID(uuidString: associationId), on: request.db) else {
+        guard let dbKey = try await Cache.shared.getAPIKey(request: request, for: associationId) else {
             throw Abort(.unauthorized, reason: "Key was not found")
         }
         

--- a/Sources/ProxLock/Middleware/DeviceValidationMiddleware.swift
+++ b/Sources/ProxLock/Middleware/DeviceValidationMiddleware.swift
@@ -166,7 +166,7 @@ struct DeviceValidationMiddleware: AsyncMiddleware {
         }
         
         // Get Project so we can fetch the user
-        guard let dbKey = try await Cache.shared.getAPIKey(request, for: associationId) else {
+        guard let dbKey = try await Cache.shared.getAPIKey(associationId, on: request.db) else {
             throw Abort(.unauthorized, reason: "Key was not found")
         }
         

--- a/Sources/ProxLock/Middleware/DeviceValidationMiddleware.swift
+++ b/Sources/ProxLock/Middleware/DeviceValidationMiddleware.swift
@@ -166,7 +166,7 @@ struct DeviceValidationMiddleware: AsyncMiddleware {
         }
         
         // Get Project so we can fetch the user
-        guard let dbKey = try await Cache.shared.getAPIKey(request: request, for: associationId) else {
+        guard let dbKey = try await Cache.shared.getAPIKey(request, for: associationId) else {
             throw Abort(.unauthorized, reason: "Key was not found")
         }
         

--- a/Sources/ProxLock/Middleware/RateLimitMiddleware.swift
+++ b/Sources/ProxLock/Middleware/RateLimitMiddleware.swift
@@ -58,7 +58,7 @@ struct RateLimitMiddleware: AsyncMiddleware {
         }
         
         // Get Project so we can fetch the user
-        guard let dbKey = try await Cache.shared.getAPIKey(request: request, for: associationId) else {
+        guard let dbKey = try await Cache.shared.getAPIKey(request, for: associationId) else {
             throw Abort(.unauthorized, reason: "Key was not found")
         }
         

--- a/Sources/ProxLock/Middleware/RateLimitMiddleware.swift
+++ b/Sources/ProxLock/Middleware/RateLimitMiddleware.swift
@@ -58,7 +58,7 @@ struct RateLimitMiddleware: AsyncMiddleware {
         }
         
         // Get Project so we can fetch the user
-        guard let dbKey = try await Cache.shared.getAPIKey(request, for: associationId) else {
+        guard let dbKey = try await Cache.shared.getAPIKey(associationId, on: request.db) else {
             throw Abort(.unauthorized, reason: "Key was not found")
         }
         

--- a/Sources/ProxLock/Middleware/RateLimitMiddleware.swift
+++ b/Sources/ProxLock/Middleware/RateLimitMiddleware.swift
@@ -50,12 +50,15 @@ struct RateLimitMiddleware: AsyncMiddleware {
     let manager: RateLimitManager
     
     func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
-        guard let associationId = request.headers.first(name: ProxyHeaderKeys.associationId) else {
+        guard let associationIdString = request.headers.first(name: ProxyHeaderKeys.associationId) else {
             throw Abort(.unauthorized, reason: "Failed Device Validation: Association ID not detected")
+        }
+        guard let associationId = UUID(uuidString: associationIdString) else {
+            throw Abort(.badRequest, reason: "Unexpected error parsing association ID from request headers.")
         }
         
         // Get Project so we can fetch the user
-        guard let dbKey = try await APIKey.find(UUID(uuidString: associationId), on: request.db) else {
+        guard let dbKey = try await Cache.shared.getAPIKey(request: request, for: associationId) else {
             throw Abort(.unauthorized, reason: "Key was not found")
         }
         

--- a/Sources/ProxLock/Migrations/DataLinkingMigrationController.swift
+++ b/Sources/ProxLock/Migrations/DataLinkingMigrationController.swift
@@ -20,11 +20,9 @@ actor APIKeyDataLinkingMigrationController {
     func getUser(forAPIKey dbKey: APIKey, on req: Request) async throws -> User {
         if dbKey.$user.id == nil {
             // Get Project
-            try await dbKey.$project.load(on: req.db)
             let project = try await dbKey.$project.cachedGet(on: req.db)
             
             // Get User
-            try await project.$user.load(on: req.db)
             let user = try await project.$user.cachedGet(on: req.db)
             
             if try !activelyLinkingUser.contains(dbKey.requireID()) {
@@ -36,7 +34,6 @@ actor APIKeyDataLinkingMigrationController {
             
             return user
         } else {
-            try await dbKey.$user.load(on: req.db)
             guard let user = try await dbKey.$user.cachedGet(on: req.db) else {
                 throw Abort(.internalServerError, reason: "Could not load User from APIKey")
             }
@@ -47,7 +44,6 @@ actor APIKeyDataLinkingMigrationController {
     
     func getDeviceCheckKey(for dbKey: APIKey, from request: Request) async throws -> DeviceCheckKey {
         if dbKey.$deviceCheckKey.id == nil {
-            try await dbKey.$project.load(on: request.db)
             let project = try await dbKey.$project.cachedGet(on: request.db)
             
             try await project.$deviceCheckKey.load(on: request.db)
@@ -76,7 +72,6 @@ actor APIKeyDataLinkingMigrationController {
     
     func getPlayIntegrityConfig(for dbKey: APIKey, from request: Request) async throws -> PlayIntegrityConfig {
         if dbKey.$playIntegrityConfig.id == nil {
-            try await dbKey.$project.load(on: request.db)
             let project = try await dbKey.$project.cachedGet(on: request.db)
             
             try await project.$playIntegrityConfig.load(on: request.db)

--- a/Sources/ProxLock/Migrations/DataLinkingMigrationController.swift
+++ b/Sources/ProxLock/Migrations/DataLinkingMigrationController.swift
@@ -21,11 +21,11 @@ actor APIKeyDataLinkingMigrationController {
         if dbKey.$user.id == nil {
             // Get Project
             try await dbKey.$project.load(on: req.db)
-            let project = try await dbKey.$project.get(on: req.db)
+            let project = try await dbKey.$project.cachedGet(on: req.db)
             
             // Get User
             try await project.$user.load(on: req.db)
-            let user = try await project.$user.get(on: req.db)
+            let user = try await project.$user.cachedGet(on: req.db)
             
             if try !activelyLinkingUser.contains(dbKey.requireID()) {
                 activelyLinkingUser.append(try dbKey.requireID())
@@ -37,7 +37,7 @@ actor APIKeyDataLinkingMigrationController {
             return user
         } else {
             try await dbKey.$user.load(on: req.db)
-            guard let user = try await dbKey.$user.get(on: req.db) else {
+            guard let user = try await dbKey.$user.cachedGet(on: req.db) else {
                 throw Abort(.internalServerError, reason: "Could not load User from APIKey")
             }
             
@@ -48,7 +48,7 @@ actor APIKeyDataLinkingMigrationController {
     func getDeviceCheckKey(for dbKey: APIKey, from request: Request) async throws -> DeviceCheckKey {
         if dbKey.$deviceCheckKey.id == nil {
             try await dbKey.$project.load(on: request.db)
-            let project = try await dbKey.$project.get(on: request.db)
+            let project = try await dbKey.$project.cachedGet(on: request.db)
             
             try await project.$deviceCheckKey.load(on: request.db)
             guard let key = try await project.$deviceCheckKey.get(on: request.db) else {
@@ -77,7 +77,7 @@ actor APIKeyDataLinkingMigrationController {
     func getPlayIntegrityConfig(for dbKey: APIKey, from request: Request) async throws -> PlayIntegrityConfig {
         if dbKey.$playIntegrityConfig.id == nil {
             try await dbKey.$project.load(on: request.db)
-            let project = try await dbKey.$project.get(on: request.db)
+            let project = try await dbKey.$project.cachedGet(on: request.db)
             
             try await project.$playIntegrityConfig.load(on: request.db)
             guard let integrityConfig = try await project.$playIntegrityConfig.get(on: request.db) else {

--- a/Sources/ProxLock/Models/User.swift
+++ b/Sources/ProxLock/Models/User.swift
@@ -68,7 +68,7 @@ final class User: Model, Authenticatable, @unchecked Sendable {
         try await $projects.load(on: db)
         let projects = try await $projects.get(on: db)
         let projectsDTOs = try await projects.asyncMap({ try await $0.toDTO(on: db) })
-        let currentRecord = try await getOrCreateCurrentMonthlyHistoricalRecord(db: db)
+        let currentRecord = try await Cache.shared.getOrCreateMonthlyUserUsageHistory(.now, userID: requireID(), on: db)
         try await $accessKey.load(on: db)
         let apiKeys = try await $accessKey.get(on: db)
         

--- a/Sources/ProxLock/configure.swift
+++ b/Sources/ProxLock/configure.swift
@@ -2,6 +2,7 @@ import NIOSSL
 import Fluent
 import FluentPostgresDriver
 import Vapor
+import Queues
 
 // configures your application
 public func configure(_ app: Application) async throws {
@@ -27,6 +28,7 @@ public func configure(_ app: Application) async throws {
     // Set Request Body Maximum
     app.routes.defaultMaxBodySize = "100mb"
 
+    // Set Migrations
     app.migrations.add(User.migrations)
     app.migrations.add(User.AccessKey.migrations)
     app.migrations.add(Project.migrations)
@@ -36,6 +38,10 @@ public func configure(_ app: Application) async throws {
     app.migrations.add(MonthlyUserUsageHistory.migrations)
     app.migrations.add(DailyUserUsageHistory.migrations)
     try await app.autoMigrate()
+    
+    // Schedule Jobs
+    app.queues.schedule(CacheCleanupJob()).minutely()
+    try app.queues.startScheduledJobs()
 
     // register routes
     try routes(app)


### PR DESCRIPTION
This is likely the first of several efforts to really improve the speed of both our proxy route as well as general dashboard use. 

## How are we achieving this?
This PR introduces a DB cache actor called `Cache`. The entire purpose of this cache is to store frequently used objects in memory so ProxLock does not have make expensive calls to the Fluent database. 

## What's Changing?
Any find/query call for a cache based object should go through `Cache`'s `shared` singleton. 

This includes `User`, `Project`, `APIKey`, `DailyUserUsageHistory`, and `MonthlyUserUsageHistory`.

## Impact
The speed of the proxy route has seen a drop of up to 850ms in response time!